### PR TITLE
add history feature in frontend ui

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,6 +22,7 @@
             <button onclick="generateSummary()">Generate Summary</button>
             <button onclick="generateFlashcards()">Generate Flashcards</button>
             <button onclick="generateQuiz()">Generate Quiz</button>
+            <button onclick="showHistory()">Show History</button>
         </section>
 
         <section class="output-section">

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -101,6 +101,109 @@ function showJsonResult(data) {
     output.appendChild(pre);
 }
 
+function showHistory() {
+    showLoading("Loading past study materials...");
+
+    fetch("http://127.0.0.1:8001/history", { credentials: "include" })
+        .then((response) => response.json())
+        .then((data) => {
+            if (data.error) {
+                showError(data.error);
+                return;
+            }
+
+            if (!Array.isArray(data.history) || data.history.length === 0) {
+                showTextResult("No past study materials were found for this session.");
+                return;
+            }
+
+            renderHistory(data.history);
+        })
+        .catch((error) => {
+            showError("Failed to load history. Please try again.");
+            console.error(error);
+        });
+}
+
+function renderHistory(items) {
+    output.innerHTML = "";
+    const historyContainer = createElement("div", "history-list");
+
+    items.forEach((item) => {
+        historyContainer.appendChild(renderHistoryItem(item));
+    });
+
+    output.appendChild(historyContainer);
+}
+
+function renderHistoryItem(item) {
+    const card = createElement("div", "history-card");
+
+    const header = createElement("div", "history-card-header");
+    header.appendChild(createElement("div", "history-type", item.type || "Unknown"));
+    header.appendChild(
+        createElement(
+            "div",
+            "history-date",
+            item.created_at ? new Date(item.created_at).toLocaleString() : "Unknown date"
+        )
+    );
+    card.appendChild(header);
+
+    const data = item.data || {};
+
+    if (item.type === "summary") {
+        card.appendChild(createElement("div", "history-item-title", "Summary"));
+        if (data.overview) {
+            card.appendChild(createElement("div", "history-overview", data.overview));
+        }
+        if (Array.isArray(data.key_points) && data.key_points.length > 0) {
+            const list = createElement("ul", "history-list-items");
+            data.key_points.forEach((point) => {
+                list.appendChild(createElement("li", undefined, point));
+            });
+            card.appendChild(list);
+        }
+    } else if (item.type === "flashcards") {
+        card.appendChild(createElement("div", "history-item-title", "Flashcards"));
+        if (Array.isArray(data.flashcards) && data.flashcards.length > 0) {
+            data.flashcards.forEach((flashcard, idx) => {
+                const flashNode = createElement("div", "history-flashcard");
+                flashNode.appendChild(createElement("div", "flashcard-number", `#${idx + 1}`));
+                flashNode.appendChild(createElement("div", "flashcard-question", flashcard.question || "No question provided."));
+                flashNode.appendChild(createElement("div", "flashcard-answer", flashcard.answer || "No answer provided."));
+                card.appendChild(flashNode);
+            });
+        }
+    } else if (item.type === "quiz") {
+        card.appendChild(createElement("div", "history-item-title", "Quiz"));
+        if (Array.isArray(data.quiz) && data.quiz.length > 0) {
+            data.quiz.forEach((quizItem, idx) => {
+                const quizNode = createElement("div", "history-quiz-item");
+                quizNode.appendChild(createElement("div", "history-quiz-question", `${idx + 1}. ${quizItem.question || "No question provided."}`));
+                if (Array.isArray(quizItem.options)) {
+                    const optionList = createElement("ul", "history-list-items");
+                    quizItem.options.forEach((option) => {
+                        optionList.appendChild(createElement("li", undefined, option));
+                    });
+                    quizNode.appendChild(optionList);
+                }
+                if (quizItem.answer_index !== undefined) {
+                    const correct = quizItem.options && quizItem.options[quizItem.answer_index]
+                        ? quizItem.options[quizItem.answer_index]
+                        : "Unknown";
+                    quizNode.appendChild(createElement("div", "history-quiz-answer", `Answer: ${correct}`));
+                }
+                card.appendChild(quizNode);
+            });
+        }
+    } else {
+        card.appendChild(createElement("pre", "history-raw", JSON.stringify(data, null, 2)));
+    }
+
+    return card;
+}
+
 function resetQuizState() {
     quizState.currentQuestionIndex = 0;
     quizState.selectedOptionIndex = null;
@@ -306,6 +409,7 @@ async function generateSummary() {
     showLoading("Generating summary...");
 
     let response = await fetch("http://127.0.0.1:8001/generate-summary", {
+        credentials: "include",
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -343,6 +447,7 @@ async function generateFlashcards() {
     showLoading("Generating flashcards...");
 
     let response = await fetch("http://127.0.0.1:8001/generate-flashcards", {
+        credentials: "include",
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -377,6 +482,7 @@ async function generateQuiz() {
     showLoading("Creating an interactive quiz...");
 
     let response = await fetch("http://127.0.0.1:8001/generate-quiz", {
+        credentials: "include",
         method: "POST",
         headers: {
             "Content-Type": "application/json",

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -258,6 +258,98 @@ pre {
     box-shadow: 0 10px 30px rgba(31, 59, 103, 0.08);
 }
 
+.history-list {
+    display: grid;
+    gap: 18px;
+}
+
+.history-card {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 22px;
+    padding: 24px;
+    box-shadow: 0 8px 24px rgba(16, 50, 90, 0.06);
+}
+
+.history-card-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 18px;
+}
+
+.history-type {
+    font-size: 0.95rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #1f3d7e;
+}
+
+.history-date {
+    font-size: 0.92rem;
+    color: #5b6b89;
+}
+
+.history-item-title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    margin-bottom: 12px;
+    color: #102a4a;
+}
+
+.history-overview,
+.history-quiz-answer,
+.flashcard-answer {
+    margin-bottom: 14px;
+}
+
+.history-list-items {
+    padding-left: 20px;
+    margin: 0 0 14px;
+    color: #2d3f56;
+}
+
+.history-list-items li {
+    margin-bottom: 8px;
+}
+
+.history-flashcard {
+    border: 1px solid #dde6f2;
+    border-radius: 18px;
+    padding: 16px;
+    margin-bottom: 14px;
+    background: #fbfdff;
+}
+
+.history-quiz-item {
+    border: 1px solid #dde6f2;
+    border-radius: 18px;
+    padding: 16px;
+    margin-bottom: 14px;
+    background: #fbfdff;
+}
+
+.history-quiz-question {
+    font-weight: 600;
+    margin-bottom: 10px;
+}
+
+.history-quiz-answer {
+    font-size: 0.96rem;
+    color: #1f3d7e;
+    margin-top: 10px;
+}
+
+.history-raw {
+    background: #f7f9fc;
+    border: 1px solid #d8e1ed;
+    border-radius: 16px;
+    padding: 20px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 .flashcard-container {
     display: grid;
     gap: 16px;


### PR DESCRIPTION
**Description:**

This PR implements the history feature in the frontend by connecting to the backend `/history` endpoint and displaying previously generated study materials.

The application can now retrieve and show past summaries, flashcards, and quizzes for the current user session, making it easier to review previous results.

**Changes made:**

* Integrated frontend with `/history` API endpoint
* Added a new UI section to display user history
* Organized history items by type (summary, flashcards, quiz)
* Improved layout for better readability

**Result:**
Users can now view their previously generated content directly in the interface, improving usability and overall experience.

**Related Issue:**
Closes #31 
